### PR TITLE
Support Rustls TLS backend in reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,15 @@ license = "MIT"
 base64 = "0.13"
 fxhash = "0.2"
 rand = "0.8"
-reqwest = "0.11"
+reqwest = {version = "0.11", default-features = false, features = [] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.3", features = ["rt"] }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 version = "3.0"
+
+[features]
+default = ["default-tls"]
+default-tls = ["reqwest/default-tls"]
+rustls-tls = ["reqwest/rustls-tls"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Create a new tracing Layer:
 
 ```rust
 let layer = tracing_elastic_apm::new_layer(
-    "ServiceName".to_string(), 
+    "ServiceName".to_string(),
     tracing_elastic_apm::Config::new("APM address".to_string())
 );
 ```
@@ -31,6 +31,14 @@ tracing_subscriber::registry()
 ```
 
 Take a look at `Config` for more configuration options.
+
+## Supported feature flags
+
+- `default-tls` _(enabled by default)_ - use default TLS backend.
+- `rustls-tls` - use Rustls TLS backend.
+
+Please see corresponding flags in the `reqwest` library for more information:
+[https://docs.rs/reqwest/0.11.2/reqwest/#optional-features](https://docs.rs/reqwest/0.11.2/reqwest/#optional-features)
 
 ## Async and time measurements
 


### PR DESCRIPTION
Disable default features and enable rustls-tls feature to use Rustls backend.