### PR TITLE
Allow invalid certs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-elastic-apm"
-version = "2.1.1"
+version = "2.1.0"
 authors = ["Kamil Rojewski <kamil.rojewski@gmail.com>"]
 edition = "2018"
 description = "Elasting APM intake API tracing layer."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-elastic-apm"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Kamil Rojewski <kamil.rojewski@gmail.com>"]
 edition = "2018"
 description = "Elasting APM intake API tracing layer."

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Create a new tracing Layer:
 ```rust
 let layer = tracing_elastic_apm::new_layer(
     "ServiceName".to_string(),
+    // remember to use desired protocol below, e.g. http://
     tracing_elastic_apm::Config::new("APM address".to_string())
 );
 ```

--- a/src/apm_client.rs
+++ b/src/apm_client.rs
@@ -80,7 +80,7 @@ impl ApmClient {
             #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
             buidler.danger_accept_invalid_hostnames(true);
 
-            builder.build().unwrap_or(Client::new())
+            builder.build().unwrap()
         } else {
             Client::new()
         };

--- a/src/apm_client.rs
+++ b/src/apm_client.rs
@@ -75,11 +75,6 @@ impl ApmClient {
             .map(Arc::new);
         let client = if allow_invalid_certs {
             let builder = reqwest::ClientBuilder::new().danger_accept_invalid_certs(true);
-
-            #[cfg(feature = "native-tls")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
-            buidler.danger_accept_invalid_hostnames(true);
-
             builder.build().unwrap()
         } else {
             Client::new()

--- a/src/apm_client.rs
+++ b/src/apm_client.rs
@@ -60,7 +60,11 @@ pub(crate) struct ApmClient {
 }
 
 impl ApmClient {
-    pub fn new(apm_address: String, authorization: Option<Authorization>) -> Self {
+    pub fn new(
+        apm_address: String,
+        authorization: Option<Authorization>,
+        allow_invalid_certs: bool,
+    ) -> Self {
         let authorization = authorization
             .map(|authorization| match authorization {
                 Authorization::SecretToken(token) => format!("Bearer {}", token),
@@ -69,11 +73,21 @@ impl ApmClient {
                 }
             })
             .map(Arc::new);
+        let client = if allow_invalid_certs {
+            let builder = reqwest::ClientBuilder::new().danger_accept_invalid_certs(true);
 
+            #[cfg(feature = "native-tls")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
+            buidler.danger_accept_invalid_hostnames(true);
+
+            builder.build().unwrap_or(Client::new())
+        } else {
+            Client::new()
+        };
         ApmClient {
             apm_address: Arc::new(apm_address),
             authorization,
-            client: Client::new(),
+            client,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,7 @@ pub struct Config {
     pub(crate) system: Option<System>,
     pub(crate) user: Option<User>,
     pub(crate) cloud: Option<Cloud>,
+    pub(crate) allow_invalid_certs: Option<bool>,
 }
 
 impl Config {
@@ -65,6 +66,11 @@ impl Config {
             apm_address,
             ..Default::default()
         }
+    }
+
+    pub fn verify_certs(mut self, verify: bool) -> Self {
+        self.allow_invalid_certs = Some(verify);
+        self
     }
 
     pub fn with_authorization(mut self, authorization: Authorization) -> Self {

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,7 +68,7 @@ impl Config {
         }
     }
 
-    pub fn verify_certs(mut self, verify: bool) -> Self {
+    pub fn allow_invalid_certificates(mut self, verify: bool) -> Self {
         self.allow_invalid_certs = Some(verify);
         self
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,7 +57,7 @@ pub struct Config {
     pub(crate) system: Option<System>,
     pub(crate) user: Option<User>,
     pub(crate) cloud: Option<Cloud>,
-    pub(crate) allow_invalid_certs: Option<bool>,
+    pub(crate) allow_invalid_certs: bool,
 }
 
 impl Config {
@@ -69,7 +69,7 @@ impl Config {
     }
 
     pub fn allow_invalid_certificates(mut self, verify: bool) -> Self {
-        self.allow_invalid_certs = Some(verify);
+        self.allow_invalid_certs = verify;
         self
     }
 

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -253,7 +253,7 @@ impl ApmLayer {
             client: ApmClient::new(
                 config.apm_address,
                 config.authorization,
-                config.allow_invalid_certs.unwrap_or(false),
+                config.allow_invalid_certs,
             ),
             metadata: json!(metadata),
         }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -250,7 +250,11 @@ impl ApmLayer {
         };
 
         ApmLayer {
-            client: ApmClient::new(config.apm_address, config.authorization),
+            client: ApmClient::new(
+                config.apm_address,
+                config.authorization,
+                config.allow_invalid_certs.unwrap_or(false),
+            ),
             metadata: json!(metadata),
         }
     }


### PR DESCRIPTION
Adds a function to the config builder to not validate certs. If the function is passed true then danger_accept_invalid_certs is added to the request client builder. This was added to support a spike we are working on to send logs to an APM cluster within our cluster but, I thought other developers may find it helpful. 