### PR TITLE
Base64 encode only ApiKey credentials

### DIFF
--- a/src/apm_client.rs
+++ b/src/apm_client.rs
@@ -69,7 +69,10 @@ impl ApmClient {
             .map(|authorization| match authorization {
                 Authorization::SecretToken(token) => format!("Bearer {}", token),
                 Authorization::ApiKey(key) => {
-                    base64::encode(format!("ApiKey {}:{}", key.id, key.key))
+                    format!(
+                        "ApiKey {}",
+                        base64::encode(format!("{}:{}", key.id, key.key))
+                    )
                 }
             })
             .map(Arc::new);


### PR DESCRIPTION
Fixes https://github.com/krojew/tracing-elastic-apm/issues/7