### PR TITLE
Remove deprecated code and useless dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ license = "MIT"
 base64 = "0.13"
 fxhash = "0.2"
 rand = "0.8"
-reqwest = {version = "0.11", default-features = false, features = [] }
+reqwest = { version = "0.11", default-features = false, features = [] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["rt"] }
 tracing = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = { version = "0.2", default-features = false }
 version = "3.0"
 anyhow = "1.0.42"
 

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -7,7 +7,7 @@ use tracing::{
     span::{Attributes, Record},
     Event, Id, Level, Subscriber,
 };
-use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
+use tracing_subscriber::{Layer, layer::Context, registry::LookupSpan};
 
 use crate::{
     apm_client::{ApmClient, Batch},
@@ -57,8 +57,8 @@ where
 
         let name = span.name().to_string();
 
-        if let Some(parent_id) = span.parent_id() {
-            let parent_span = ctx.span(parent_id).expect("Span parent not found!");
+        if let Some(parent_id) = span.parent().map(|span_ref| span_ref.id()) {
+            let parent_span = ctx.span(&parent_id).expect("Span parent not found!");
             let parent_extensions = parent_span.extensions();
             let trace_ctx = parent_extensions
                 .get::<TraceContext>()


### PR DESCRIPTION
From `tracing_subscribe` 0.2.21, the `span.parent_id()` is deprecated.
This PR removes the deprecated code and reduces the number of dependencies disabling the `tracing_subscribe` default features.