### PR TITLE
feat: Record error using `tracing` instead of `errprintln`

### DIFF
--- a/src/apm_client.rs
+++ b/src/apm_client.rs
@@ -136,7 +136,7 @@ impl ApmClient {
 
             let result = request.send().await;
             if let Err(error) = result {
-                eprintln!("Error sending batch to APM: {}", error);
+                tracing::warn!(%error, "Error sending batch to APM");
             }
         });
     }


### PR DESCRIPTION
This lets it be filtered, amended, enhanced in the rest of the tracing ecosystem we are already in